### PR TITLE
refactor(src/bot): refactoring play and skip - adding current playing…

### DIFF
--- a/src/bot/commands/command-play.ts
+++ b/src/bot/commands/command-play.ts
@@ -46,24 +46,24 @@ export class Play extends Command {
 
       const player = this.getPlayer(voiceMember.channelId);
       connection.subscribe(player);
+
       const queue = this.getQueue();
+      queue.add(voiceMember.channelId, {
+        audioResource,
+        streamInfo,
+        userSearch: input,
+      });
+
+      let replyContent = `${message.author.username} ${BOT_MESSAGES.PUSHED_TO_QUEUE} ${streamInfo.title}`;
 
       if (player.state.status === AudioPlayerStatus.Idle) {
         player.play(audioResource);
         const playHook = new PlayHook(this.bot);
         playHook.execute(message);
-        await message.reply({
-          content: `${message.author.username} ${BOT_MESSAGES.CURRENT_PLAYING} ${streamInfo.title}`,
-        });
-      } else {
-        queue.add(voiceMember.channelId, {
-          audioResource,
-          streamInfo,
-        });
-        await message.reply({
-          content: `${message.author.username} ${BOT_MESSAGES.PUSHED_TO_QUEUE} ${streamInfo.title}`,
-        });
+        replyContent = `${message.author.username} ${BOT_MESSAGES.CURRENT_PLAYING} ${streamInfo.title}`;
       }
+
+      await message.channel.send(replyContent);
     } catch (err) {
       await this.sendCommandError(err, message);
     }

--- a/src/bot/commands/command-shuffle.ts
+++ b/src/bot/commands/command-shuffle.ts
@@ -11,9 +11,8 @@ export class Shuffle extends Command {
 
   async execute(message: Message<boolean>): Promise<void> {
     try {
-
+      await this.validate(message, 'shuffle');
       this.getQueue().shuffle(message.member.voice.channelId);
-
       new ListQueue(this.bot).execute(message);
     } catch (error) {
       await this.sendCommandError(error, message);

--- a/src/bot/commands/command-skip.ts
+++ b/src/bot/commands/command-skip.ts
@@ -16,8 +16,8 @@ export class Skip extends Command {
       const player = this.getPlayer(connectionID);
       const queue = this.getQueue();
       const playlist = queue.getList(connectionID);
-      if (playlist.length) {
-        const next = playlist[0];
+      if (playlist?.length > 1) {
+        const next = playlist[1];
         await message.reply(
           `${BOT_MESSAGES.MUSIC_SKIPPED} ${next.streamInfo.title}`
         );

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -5,6 +5,7 @@ import { shuffleArray } from '../helpers/helpers';
 export interface QueueData {
   streamInfo: StreamInfo;
   audioResource: AudioResource;
+  userSearch: string;
 }
 
 export abstract class Queue {


### PR DESCRIPTION
Refactor for play and skip commands: 
- Now when you run play command, bot also adds the current music to the queue if it is stopped
- Consequently, the skip command now skips to the queue[1] (second on the list)
-  Now we include user's input search to queue items, so we can retrieve that info later when we need